### PR TITLE
Remove temp file created

### DIFF
--- a/todo.actions.d/note
+++ b/todo.actions.d/note
@@ -99,6 +99,8 @@ case "$TODO_NOTE_ACTION" in
     notename=$(basename "$filename${TODO_NOTE_EXT}")
     title=$(echo "$todo" | sed -e "s/^\(x ....-..-.. \)\?//" -e "s/^(.) \?//")
     echo \# $title > "$TODO_NOTES_DIR/${notename}"
+    # remove temp file created
+    rm -f "${filename}"
 
     # Append note tag to task
     sed -i.bak $item" s/$/ ${TODO_NOTE_TAG}:$notename/" "$TODO_FILE"


### PR DESCRIPTION
Explicitly removes the temporary file created for randomising the note name.

On my system (Elementary 5.1) Based on Ubuntu 18.04 LTS. I am using the .md file extension added into the todo config file as suggested.  When creating a note, it creates two files, one with the.md extension and one with no extension so I have to rm the random generated file. Not sure if this is replicated on other systems, but explicitly removing it should not cause a problem if it doesn't exist.