### PR TITLE
Only try to delete note if note exits.

### DIFF
--- a/todo.actions.d/note
+++ b/todo.actions.d/note
@@ -140,7 +140,11 @@ case "$TODO_NOTE_ACTION" in
 
 "__rmfromtext")
     getnotenamefromtext "$*"
-    rm -f "$TODO_NOTES_DIR/$notename"
+    
+    if [ $notename ]
+    then
+        rm -f "$TODO_NOTES_DIR/$notename"
+    fi
     ;;
 
 *)


### PR DESCRIPTION
Currently when using `del` or `rm` if there is no note attached to the task you get an error as it tries to remove the notes directory.
`rm: cannot remove '/home/todo/notes/': Is a directory`.

This patch just checks if a note is attached before attempting to delete.