### PR TITLE
option to choose pager for note show added

### DIFF
--- a/todo.actions.d/README.md
+++ b/todo.actions.d/README.md
@@ -56,9 +56,10 @@ Copy the `archive`, `del` and `rm` files in this directory to your add-ons folde
 
 ## Configuration
 
-You can change the note file extension by adding an entry to your `todo.cfg` file:
+You can change the note file extension or pager used for showing notes by adding an entry to your `todo.cfg` file:
 
 ```
 # Note file extension
 export TODO_NOTE_EXT=.md
+export TODO_NOTE_PAGER=less
 ```

--- a/todo.actions.d/note
+++ b/todo.actions.d/note
@@ -5,6 +5,7 @@ TODO_NOTE_TAG=${TODO_NOTE_TAG:-note}
 TODO_NOTE_TEMPLATE=${TODO_NOTE_TEMPLATE:-XXX}
 TODO_NOTE_EXT=${TODO_NOTE_EXT:-.txt}
 TODO_NOTE_ARCHIVE="$TODO_NOTES_DIR/archive$TODO_NOTE_EXT"
+TODO_NOTE_PAGER=${TODO_NOTE_PAGER:-cat}
 
 usage() {
     echo "    $(basename $0) add|a ITEM#"
@@ -124,7 +125,7 @@ case "$TODO_NOTE_ACTION" in
 "show" | "s")
     errmsg="usage: $TODO_SH $(basename $0) show|s ITEM#|archive|a"
     getnotefilepath $*
-    cat "$notefilepath"
+    $TODO_NOTE_PAGER "$notefilepath"
     ;;
 
 "__archive")


### PR DESCRIPTION
added a variable for the pager used (default `cat`), so that the user can choose the pager by adding an option to the config file.

I personally like to use .md files with [mdcat](https://github.com/lunaryorn/mdcat).