### PR TITLE
use todo.txt builtin append command to append note tag

### DIFF
--- a/todo.actions.d/note
+++ b/todo.actions.d/note
@@ -101,10 +101,9 @@ case "$TODO_NOTE_ACTION" in
     echo \# $title > "$TODO_NOTES_DIR/${notename}"
 
     # Append note tag to task
-    sed -i.bak $item" s/$/ ${TODO_NOTE_TAG}:$notename/" "$TODO_FILE"
+    "$TODO_SH" command append "$item" "${TODO_NOTE_TAG}:$notename"
 
     getTodo "$item"
-    echo $item $todo
     echo TODO: Note added to task $item.
 
     echo "Edit note?  (y/n)"


### PR DESCRIPTION
I did this because occasionally I would get the note tag on the new line when using the original script.